### PR TITLE
allow to use ssh agent globally

### DIFF
--- a/cmd/start-ssh-agent.cmd
+++ b/cmd/start-ssh-agent.cmd
@@ -79,6 +79,14 @@
 @ENDLOCAL & @SET "SSH_AUTH_SOCK=%SSH_AUTH_SOCK%" ^
           & @SET "SSH_AGENT_PID=%SSH_AGENT_PID%"
 
+@REM Set variables globally
+@where setx
+@if %ERRORLEVEL% == 0 (
+	@echo Setup global vars
+	@setx SSH_AGENT_PID %SSH_AGENT_PID%
+	@setx SSH_AUTH_SOCK %SSH_AUTH_SOCK%
+)
+
 @ECHO %cmdcmdline% | @FINDSTR /l "\"\"" >NUL
 @IF NOT ERRORLEVEL 1 @(
     @CALL cmd %*


### PR DESCRIPTION
Git can be used in separated consoles or in different programs (VSCode, GitExtensions,..) and all of them has to have access to started ssh-agent. But this require global SSH-variables.
Here is my solution for that.