### PR TITLE
Add a GitHub Action to upload some artifacts to Azure Blobs

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -1,0 +1,36 @@
+name: ci-artifacts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  ci-artifact:
+    strategy:
+      matrix:
+        artifact: [full-sdk, build-installers]
+    runs-on: windows-latest
+    steps:
+      - name: clone git-sdk-32
+        run: git clone --bare --depth=1 --single-branch -b master https://github.com/git-for-windows/git-sdk-32
+      - name: clone build-extra
+        run: git clone --depth=1 --single-branch -b master https://github.com/git-for-windows/build-extra
+      - name: build git-sdk-32-${{matrix.artifact}}
+        shell: bash
+        run: |
+          sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-32.git ${{matrix.artifact}}
+          echo "::set-env name=ARTIFACT_PATH::$(echo ${{matrix.artifact}}/*.tar.xz)"
+      - name: compress artifact
+        if: matrix.artifact != 'full-sdk'
+        shell: bash
+        run: |
+          (cd ${{matrix.artifact}} && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-32-${{matrix.artifact}}.tar.xz
+          echo "::set-env name=ARTIFACT_PATH::$(echo *.tar.xz)"
+      - name: upload to Azure Blobs
+        uses: fixpoint/azblob-upload-artifact@v3
+        with:
+          connection-string: ${{secrets.CI_ARTIFACTS_CONNECTION_STRING}}
+          name: .
+          path: ${{env.ARTIFACT_PATH}}
+          container: ci-artifacts

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ci-artifact:
+    if: github.event.repository.fork == false
     strategy:
       matrix:
         artifact: [full-sdk, build-installers]


### PR DESCRIPTION
In Azure Pipelines, we publish a couple Build Artifacts for use by other
Azure Pipelines:

- full-sdk (x86_64 and i686)
- build-installers (x86_64 and i686)
- makepkg-git (x86_64 only)
- minimal (x86_64 only)

As we want to switch to GitHub Actions, we need a different way to
access those artifacts. The solution we settled on is to download
`.tar.xz` files from Azure Blobs and simultaneously extract them, in a
Bash step (which uses Git for Windows' Git Bash, which comes with the
required `curl`, `tar` and `xz`) essentially by calling

        curl <url> | tar xJf -

With this commit, we generate and upload the i686 ones.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>