### PR TITLE
makepkg-git: accommodate for gettext v0.23.*

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -179,6 +179,7 @@
 /mingw32/bin/libintl-*.dll
 /mingw32/bin/libgettext*.dll
 /mingw32/bin/libiconv-*.dll
+/mingw32/bin/libtextstyle-*[0-9].dll
 
 # 32-bit Tcl (to emulate msgfmt, *somewhere*)
 /mingw32/bin/tclsh.exe


### PR DESCRIPTION
As of `mingw-w64-gettext-runtime` (0.22.5-2 -> 0.23.1-1), `msgfmt.exe` now depends on a newly-introduced library, gettext-libtextstyle. So let's include that in the `makepkg-git` sparse checkout, too.

This is a companion of https://github.com/git-for-windows/git-sdk-64/pull/90