### PR TITLE
makepkg-git: accommodate for Ruby v3.4.0

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -81,6 +81,7 @@
 /mingw32/lib/ruby/*/i386-mingw32/enc/windows_1252.so
 /mingw32/lib/ruby/*/optparse.rb
 /mingw32/lib/ruby/*/i386-mingw32/strscan.so
+/mingw32/lib/ruby/*/strscan/strscan.rb
 /mingw32/lib/ruby/*/pathname.rb
 /mingw32/lib/ruby/*/i386-mingw32/pathname.so
 /mingw32/lib/ruby/*/did_you_mean*


### PR DESCRIPTION
In that version, `strscan` not only has a native library but also Ruby code that we need to provide to be able to run `asciidoctor` (which is used to render Git's documentation).

This is a companion to https://github.com/git-for-windows/git-sdk-64/pull/93 and to https://github.com/git-for-windows/git-sdk-arm64/pull/31.