### PR TITLE
update-via-pacman.ps1: sync dbs when re-installing git-extra

### DIFF
--- a/update-via-pacman.ps1
+++ b/update-via-pacman.ps1
@@ -155,4 +155,4 @@ if ($pacnew.Length -gt 0) {
 }
 
 # Wrapping up: re-install mingw-w64-git-extra
-bash -lc "pacman -S --overwrite=\* --noconfirm mingw-w64-i686-git-extra"
+bash -lc "pacman -Sy --overwrite=\* --noconfirm mingw-w64-i686-git-extra"


### PR DESCRIPTION
If pacman.conf was updated to add a new sync db (as it was in the latest i686 sync, to add clangarm64), not all databases would be present and pacman would error out.