### PR TITLE
Mark required packages as explicitly installed.

### DIFF
--- a/var/lib/pacman/local/mingw-w64-i686-gettext-tools-0.23.1-1/desc
+++ b/var/lib/pacman/local/mingw-w64-i686-gettext-tools-0.23.1-1/desc
@@ -20,16 +20,13 @@ any
 1736176090
 
 %INSTALLDATE%
-1736306414
+1739859434
 
 %PACKAGER%
 CI (msys2/msys2-autobuild/35ff0b71/12634887428)
 
 %SIZE%
 16904428
-
-%REASON%
-1
 
 %LICENSE%
 spdx:GPL-3.0-or-later
@@ -52,4 +49,7 @@ mingw-w64-i686-gettext<=0.22.4-3
 
 %PROVIDES%
 mingw-w64-i686-gettext=0.23.1-1
+
+%XDATA%
+pkgtype=split
 

--- a/var/lib/pacman/local/perl-XML-Parser-2.46-8/desc
+++ b/var/lib/pacman/local/perl-XML-Parser-2.46-8/desc
@@ -20,16 +20,13 @@ i686
 1739828374
 
 %INSTALLDATE%
-1739848753
+1739859434
 
 %PACKAGER%
 Johannes Schindelin <johannes.schindelin@gmx.de>
 
 %SIZE%
 427685
-
-%REASON%
-1
 
 %GROUPS%
 perl-modules


### PR DESCRIPTION
Result of running:
```
pacman -S --dbonly --asexplicit mingw-w64-i686-gettext-tools perl-XML-Parser
```

Part of #39