### PR TITLE
Downgrade mingw-w64-git to allow big fetches again

### DIFF
--- a/.github/workflows/downgrade-git.yml
+++ b/.github/workflows/downgrade-git.yml
@@ -1,0 +1,60 @@
+name: downgrade-git-from-v2.50.0-rc0
+
+on:
+  push:
+    branches:
+    - temporarily-downgrade-git
+
+env:
+  GIT_CONFIG_PARAMETERS: "'user.name=Git for Windows Build Agent' 'user.email=ci@git-for-windows.build' 'http.sslbackend=schannel' 'core.autocrlf=false' 'checkout.workers=56'"
+  HOME: "${{ github.workspace }}\\home\\git-ci"
+  MSYSTEM: MINGW32
+
+jobs:
+  downgrade-git:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: clone git-sdk-32
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - name: use git-sdk-32's Bash and Git for Windows' git.exe
+        run: "usr\\bin\\bash.exe -lc 'cygpath -aw /usr/bin >>$GITHUB_PATH && cygpath -aw /c/Program\\ Files/Git/cmd/ >>$GITHUB_PATH'"
+      - name: download Pacman packages
+        id: download
+        shell: bash
+        run: |
+          set -ex
+
+          # Only do this if mingw-w64-i686-git is at v2.50.0-rc0 (known bad)
+          test -d var/lib/pacman/local/mingw-w64-i686-git-2.50.0.rc0.windows.1-1 || exit 0
+
+          for f in \
+            mingw-w64-i686-git-2.49.0.1.cca1f38702-1-any.pkg.tar.xz \
+            mingw-w64-i686-git-2.49.0.1.cca1f38702-1-any.pkg.tar.xz.sig \
+            mingw-w64-i686-git-doc-html-2.49.0.1.cca1f38702-1-any.pkg.tar.xz \
+            mingw-w64-i686-git-doc-html-2.49.0.1.cca1f38702-1-any.pkg.tar.xz.sig
+          do
+            curl -fsLO https://github.com/git-for-windows/pacman-repo/releases/download/2025-03-17T09-41-32.275727400Z/$f
+          done
+          echo "result=$(echo *.pkg.tar.xz)" >>$GITHUB_OUTPUT
+      - name: give the `/etc/profile.d/` scripts a chance to set things up
+        if: steps.download.outputs.result != ''
+        shell: bash
+        run: |
+          bash -lc 'uname -a'
+      - name: install ${{ steps.download.outputs.result }}
+        if: steps.download.outputs.result != ''
+        shell: pwsh
+        run: pacman -U --noconfirm ${{ steps.download.outputs.result }}
+      - name: commit ${{ steps.download.outputs.result }}
+        if: steps.download.outputs.result != ''
+        shell: bash
+        run: |
+          rm ${{ steps.download.outputs.result }} *.pkg.tar.xz.sig &&
+          git add -A &&
+          git commit -m 'Downgrade mingw-w64-git to a version without the mimalloc bug' \
+            -m 'This bug prevents fetching git-for-windows/git'\''s `main` branch' &&
+          git push origin HEAD


### PR DESCRIPTION
The `git-artifacts` workflow failed in a step that tried to fetch git-for-windows/git's `main` branch.

The reason is this mimalloc bug:
https://github.com/microsoft/mimalloc/issues/1025

Unfortunately, I cannot deploy a fixed version (namely, v2.50.0-rc1) with the current git-sdk-32 revision because it would not be able to fetch the fixed version...

So let's downgrade `mingw-w64-i686-git` in preparation for upgrading it.