### PR TITLE
ci: drop installer and portable artifacts from matrix

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -142,7 +142,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        artifact: [portable, mingit]
+        artifact: [mingit]
       fail-fast: false
     steps:
       - name: Download pkg-${{env.ARCH_NAME}}

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -142,7 +142,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        artifact: [installer, portable, mingit]
+        artifact: [portable, mingit]
       fail-fast: false
     steps:
       - name: Download pkg-${{env.ARCH_NAME}}
@@ -175,61 +175,9 @@ jobs:
             --${{matrix.artifact}} \
             $(ls pkg-$ARCH_NAME/mingw-w64-*.pkg.tar.* |
               sed '/\.sig$/d;/archimport/d;/cvs/d;/p4/d;/gitweb/d;/doc-man/d;s/^/--pkg=/')
-      - name: Copy package-versions and pdbs
-        if: matrix.artifact == 'installer'
-        shell: bash
-        run: |
-          cp /usr/src/build-extra/installer/package-versions.txt artifacts/ &&
-
-          a=$PWD/artifacts &&
-          p=$PWD/pkg-${{env.ARCH_NAME}} &&
-          (cd /usr/src/build-extra &&
-          mkdir -p cached-source-packages &&
-          cp "$p"/*-pdb* cached-source-packages/ &&
-          GIT_CONFIG_PARAMETERS="'windows.sdk${{env.ARCH_BITNESS}}.path='" ./please.sh bundle_pdbs --arch=${{env.ARCH_NAME}} --directory="$a" installer/package-versions.txt)
       - name: Publish ${{matrix.artifact}}-${{env.ARCH_NAME}}
         uses: actions/upload-artifact@v7
         with:
           name: ${{matrix.artifact}}-${{env.ARCH_NAME}}
           path: artifacts
           retention-days: 5
-
-      - name: Run the installer
-        if: matrix.artifact == 'installer'
-        shell: pwsh
-        run: |
-          $exePath = Get-ChildItem -Path artifacts/*.exe | %{$_.FullName}
-          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
-          $exitCode = $installer.ExitCode
-          if ($exitCode -ne 0) {
-            Write-Host "::error::Installer failed with exit code $exitCode!"
-            exit 1
-          }
-          "${env:ProgramFiles(x86)}\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-          "${env:ProgramFiles(x86)}\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-      - name: Publish installer log
-        if: matrix.artifact == 'installer' && (failure() || success())
-        uses: actions/upload-artifact@v7
-        with:
-          name: installer.log
-          path: installer.log
-          retention-days: 5
-      - name: Validate
-        if: matrix.artifact == 'installer'
-        shell: bash
-        run: |
-          echo '::group::installer.log'
-          cat installer.log
-          echo '::endgroup'
-
-          set -x &&
-          grep 'Installation process succeeded' installer.log &&
-          ! grep -iw failed installer.log &&
-          cygpath -aw / &&
-          git.exe version --build-options >version &&
-          cat version &&
-          grep "$(sed -e 's|^v||' -e 's|-|.|g' <bundle-artifacts/next_version)" version &&
-          checklist=build-installers/usr/src/build-extra/installer/run-checklist.sh &&
-          # cannot test SSH keys in read-only mode, skip test for now
-          sed -i 's|git@ssh.dev.azure.com:v3/git-for-windows/git/git|https://github.com/git/git|' $checklist &&
-          sh -x $checklist


### PR DESCRIPTION
Git for Windows v2.48.1 was the last version to ship a 32-bit installer; since then only 32-bit MinGit is built, and that only until April 2029. See https://gitforwindows.org/32-bit.html for the background.

We can therefore remove the installer from the SDK artifacts, so that the actual installer logic can be cleaned up as well.

Ref: https://github.com/git-for-windows/build-extra/pull/733